### PR TITLE
Fix toast not displayed

### DIFF
--- a/app/src/main/java/com/gttcgf/nanoscan/SelectDeviceViewActivity.java
+++ b/app/src/main/java/com/gttcgf/nanoscan/SelectDeviceViewActivity.java
@@ -179,7 +179,7 @@ public class SelectDeviceViewActivity extends AppCompatActivity implements View.
     @SuppressLint("MissingPermission")
     private void scanLeDevice(boolean enable) {
         if (mBluetoothLeScanner == null) {
-            Toast.makeText(this, "蓝牙未启用！", Toast.LENGTH_SHORT);
+            Toast.makeText(this, "蓝牙未启用！", Toast.LENGTH_SHORT).show();
         } else {
             if (enable) {
                 handler.postDelayed(() -> {


### PR DESCRIPTION
## Summary
- fix missing `show()` when notifying that bluetooth isn't enabled

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f9ba2e0ac832c99e70b1f2dde1777