### PR TITLE
Simplify getBytetoString and add unit tests

### DIFF
--- a/app/src/main/java/com/gttcgf/nanoscan/tools/PasswordUtils.java
+++ b/app/src/main/java/com/gttcgf/nanoscan/tools/PasswordUtils.java
@@ -30,27 +30,13 @@ public class PasswordUtils {
     }
 
     public static String getBytetoString(byte[] configName) {
-        byte[] byteChars = new byte[40];
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        byte[] var3 = byteChars;
-        int i = byteChars.length;
-        for (int var5 = 0; var5 < i; ++var5) {
-            byte b = var3[var5];
-            byteChars[b] = 0;
-        }
-        String s = null;
-        for (i = 0; i < configName.length; ++i) {
-            byteChars[i] = configName[i];
-            if (configName[i] == 0) {
+        for (byte b : configName) {
+            if (b == 0) {
                 break;
             }
-            os.write(configName[i]);
+            os.write(b);
         }
-        try {
-            s = os.toString("UTF-8");
-        } catch (UnsupportedEncodingException var7) {
-            var7.printStackTrace();
-        }
-        return s;
+        return os.toString(StandardCharsets.UTF_8.name());
     }
 }

--- a/app/src/test/java/com/gttcgf/nanoscan/tools/PasswordUtilsTest.java
+++ b/app/src/test/java/com/gttcgf/nanoscan/tools/PasswordUtilsTest.java
@@ -1,0 +1,21 @@
+package com.gttcgf.nanoscan.tools;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class PasswordUtilsTest {
+    @Test
+    public void convertsByteArrayWithTerminator() {
+        byte[] input = new byte[] { 'h', 'e', 'l', 'l', 'o', 0 };
+        String result = PasswordUtils.getBytetoString(input);
+        assertEquals("hello", result);
+    }
+
+    @Test
+    public void convertsByteArrayWithoutTerminator() {
+        byte[] input = new byte[] { 'w', 'o', 'r', 'l', 'd' };
+        String result = PasswordUtils.getBytetoString(input);
+        assertEquals("world", result);
+    }
+}


### PR DESCRIPTION
## Summary
- simplify `getBytetoString` implementation
- add unit tests for byte array conversions

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fea91b010832cb7212a767df1bd34