### PR TITLE
Clamp progress in CircularProgressBarView

### DIFF
--- a/app/src/main/java/com/gttcgf/nanoscan/CircularProgressBarView.java
+++ b/app/src/main/java/com/gttcgf/nanoscan/CircularProgressBarView.java
@@ -111,9 +111,9 @@ public class CircularProgressBarView extends View {
      * @param time     动画时间范围
      */
     public synchronized void setProgress(final int progress, int time) {
+        mProgress = Math.max(0, Math.min(progress, maxProgress));
         anim.setDuration(time);
-        this.startAnimation(anim);
-        this.mProgress = progress;
+        startAnimation(anim);
     }
 
     // 动画


### PR DESCRIPTION
### Motivation
- Prevent invalid sweep angles when `setProgress` receives out-of-range values by clamping the progress to the valid range.

### Description
- In `CircularProgressBarView.setProgress(int, int)` clamp `progress` with `mProgress = Math.max(0, Math.min(progress, maxProgress));` before starting the animation to avoid negative or oversized `progressSweepAngle` values.

### Testing
- No automated tests were run for this change (`not run`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69678e2a5ab0832c82733926cffb0529)